### PR TITLE
[SparkR-237][WIP] Work around fix with cleanClosure() in SparkR.

### DIFF
--- a/pkg/R/arrange-like.R
+++ b/pkg/R/arrange-like.R
@@ -174,7 +174,7 @@ merge.counts =
     
     merge.one =
       function(x)
-        ddply(
+        plyr::ddply(
           x, 
           1:(ncol(x)-1), 
           function(x)

--- a/pkg/R/common.R
+++ b/pkg/R/common.R
@@ -268,7 +268,7 @@ deVAR =
 
 lazy.eval = 
 	function(x, data) 
-		lazy_eval(x, c(data, list(.data = data)))
+		lazyeval::lazy_eval(x, c(data, list(.data = data)))
 		
 
 #pipes

--- a/pkg/R/pipespark.R
+++ b/pkg/R/pipespark.R
@@ -46,13 +46,13 @@ set.keycols =
 		kv}
 
 add.keycols = 
-	function(kv, keycols) {
-		attr(kv, 'keys') = union(keycols(kv), keycols)
+	function(kv, kcols) {
+		attr(kv, 'keys') = union(keycols(kv), kcols)
 		kv}
 
 rm.keycols = 
-	function(kv, keycols) {
-		attr(kv, 'keys') = setdiff(keycols(kv), keycols)
+	function(kv, kcols) {
+		attr(kv, 'keys') = setdiff(keycols(kv), kcols)
 		kv}
 
 keys.spark = function(kv) kv[, keycols(kv), drop = FALSE]
@@ -109,7 +109,7 @@ kv2rdd.list =
 					function(x) {
 						x = unique(x)
 						attributes(x) = NULL
-						digest(x)}), 
+						digest::digest(x)}), 
 				unname(split(kv, k, drop = TRUE)), 
 				SIMPLIFY = FALSE)}
 

--- a/pkg/R/sqlish.R
+++ b/pkg/R/sqlish.R
@@ -14,7 +14,12 @@
 
 where.pipe = 
 	function(.data, .cond) {
+		print("driver")
 		.cond = lazy(.cond)
+		 # copy environment.
+		env <- as.environment(as.list(.cond$env))
+		parent.env(env) <- .GlobalEnv
+		.cond$env <- env
 		gapply(.data, where.data.frame_, .cond)}
 
 transmute.pipe = 


### PR DESCRIPTION
@piccolbo I have submitted a new patch in `SparkR` that fixes some of the major issues of `cleanClosure`. Some other issues might take longer to fix, so I submitted this PR as a quick work around with minimal changes to `plyrmr`. Currently in my local setup, it passes the examples but fails at the first test. If you have time, you could try this patch and maybe give me some pointers about the error messages. Thanks. 
